### PR TITLE
Fixes Issue36

### DIFF
--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -584,6 +584,10 @@ class apibridge {
         $event->set_presentation($job->fileid);
         $storedfile = $event->get_presentation();
 
+        if(!$storedfile) {
+            return false;
+        }
+
         $event->add_meta_data('title', $storedfile->get_filename());
         $event->add_meta_data('isPartOf', $seriesidentifier);
         $params = $event->get_form_params();


### PR DESCRIPTION
This commit fixes Issue #36. 
Now an exception is thrown which is catched by the block. Therefore the cron job is not blocked by the block anymore.

However, we should think about a more detailed approach how to handle deleted files. I think that we should delete an upload job if the associated file was deleted.