### PR TITLE
fixed admin settings layout

### DIFF
--- a/classes/admin_form.php
+++ b/classes/admin_form.php
@@ -172,8 +172,6 @@ class admin_form extends moodleform {
         $this->table_body();
 
         $mform->addElement('submit', 'submitbutton', get_string('submit', 'block_opencast'));
-
-        $mform->addElement('html', '</div>');
     }
 
     /**


### PR DESCRIPTION
The admin settings page looks strange because the admin form corrupts the HTML.
I've fixed this by deleting the wrong div closing tag.