### PR TITLE
WIP : Fix the depiction of the visibility icon

### DIFF
--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -863,7 +863,7 @@ class apibridge {
     }
 
     /**
-     * Checks if momentarily not permanent roles are added or not.
+     * Checks if momentarily not permanent roles have the necessary actions for a event to be visible.
      *
      * @param $eventidentifier
      * @param $courseid
@@ -878,22 +878,27 @@ class apibridge {
 
         $numroles = 0;
         $roles = $this->getroles(array('permanent' => 0));
+        $hassomeactions = false;
+        // The loop counts the number of roles who have all necessary access rights($numroles, $hasallactions) ...
+        // ... and identifies at least one role has the permission for one action ($hassomeaction).
         foreach ($roles as $role) {
             $hasallactions = true;
             foreach ($role->actions as $action) {
                 if (!$event->has_acl(true, $action, $this->replace_placeholders($role->rolename, $courseid))) {
                     $hasallactions = false;
-                    break;
+                } else {
+                    $hassomeactions = true;
                 }
             }
             if ($hasallactions) {
                 $numroles++;
             }
         }
-
+        // If all non permanent roles have all necessary actions the event is visible.
         if ($numroles === count($roles)) {
             return \block_opencast_renderer::VISIBLE;
-        } else if ($numroles === 0) {
+        } else if ($numroles === 0 && !$hassomeactions) {
+            // The visibility is hidden if no role has a permission for one of the action.
             return \block_opencast_renderer::HIDDEN;
         } else {
             return \block_opencast_renderer::MIXED_VISIBLITY;

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -873,17 +873,21 @@ class apibridge {
         $resource = '/api/events/' . $eventidentifier . '/acl';
         $api = new api();
         $jsonacl = $api->oc_get($resource);
-
         $event = new \block_opencast\local\event();
         $event->set_json_acl($jsonacl);
 
         $numroles = 0;
         $roles = $this->getroles(array('permanent' => 0));
         foreach ($roles as $role) {
+            $hasallactions = true;
             foreach ($role->actions as $action) {
-                if ($event->has_acl(true, $action, $this->replace_placeholders($role->rolename, $courseid))) {
-                    $numroles++;
+                if (!$event->has_acl(true, $action, $this->replace_placeholders($role->rolename, $courseid))) {
+                    $hasallactions = false;
+                    break;
                 }
+            }
+            if ($hasallactions) {
+                $numroles++;
             }
         }
 


### PR DESCRIPTION
### Previously:

-  The number of action all not permanent roles have was counted.

### Now:

- The number of roles who have all necessary actions is counted.

- It is checked whether some role has one of the actions. 

If every not permanent role has all actions the event is visible.
If no role has all actions and no role has someactions the event is hidden.
In any other case, the visibility is mixed.

Needs to be tested @tobiasreischmann .