### PR TITLE
Link publications to their URL unless there is also media attached.

### DIFF
--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -235,6 +235,29 @@ class apibridge {
         return $result;
     }
 
+    public function get_opencast_video_publications($identifier) {
+        $resource = '/api/events/' . $identifier . '/publications';
+        $api = new api();
+
+        $publications = $api->oc_get($resource);
+
+        $result = new \stdClass();
+        $result->publications = false;
+        $result->error = 0;
+
+        if ($api->get_http_code() != 200) {
+            $result->error = $api->get_http_code();
+            return $result;
+        }
+
+        if (!$publications = json_decode($publications)) {
+            return $result;
+        }
+
+        $result->publications = $publications;
+        return $result;
+    }
+
     /**
      * API call to check, whether the course related group exists in opencast system.
      *

--- a/index.php
+++ b/index.php
@@ -170,7 +170,7 @@ if ($videodata->error == 0) {
         $row[] = $video->location;
 
         if (get_config('block_opencast', 'showpublicationchannels')) {
-            $row[] = $renderer->render_publication_status($video->publication_status);
+            $row[] = $renderer->render_publication_status($video->identifier, $video->publication_status);
         }
 
         $row[] = $renderer->render_processing_state_icon($video->processing_state);

--- a/renderer.php
+++ b/renderer.php
@@ -125,13 +125,29 @@ class block_opencast_renderer extends plugin_renderer_base {
      *
      * @return string
      */
-    public function render_publication_status($publicationstatus) {
+    public function render_publication_status($identifier, $publicationstatus) {
 
         if (empty($publicationstatus)) {
             return get_string('notpublished', 'block_opencast');
         }
 
-        return implode(', ', $publicationstatus);
+        $opencast = \block_opencast\local\apibridge::get_instance();
+        $publications = $opencast->get_opencast_video_publications($identifier);
+        if ($publications->error) {
+            // fall back to text status
+            $result = $publicationsstatus;
+        } else {
+            $result = array();
+            foreach ($publications->publications as $publication) {
+                if ($publication->media) {
+                    // avoid picking an arbitrary one
+                    $result[] = $publication->channel;
+                } else {
+                    $result[] = "<a href='$publication->url'>$publication->channel</a>";
+                }
+            }
+        }
+        return implode(', ', $result);
     }
 
     /**


### PR DESCRIPTION
In the block, it would be useful if it actually showed the URL where it video is published (in particular for engage). This patch does that. When I first implemented it, it linked the "api" publication in a bogus manner. This is because the real meat of that is in the media and attachments, but there is no meaningful way to link all of them. So I decided to link nothing if there is no clear preferred link target.