### PR TITLE
Call a delete workflow before actual deletion of an event

### DIFF
--- a/adminsettings.php
+++ b/adminsettings.php
@@ -94,6 +94,9 @@ if (has_capability('moodle/site:config', context_system::instance())) {
             if (isset($data->allowunassign)) {
                 set_config('allowunassign', $data->allowunassign, 'block_opencast');
             }
+            if (isset($data->deleteworkflow)) {
+                set_config('deleteworkflow', $data->deleteworkflow, 'block_opencast');
+            }
             if (isset($data->adhocfiledeletion)) {
                 set_config('adhocfiledeletion', $data->adhocfiledeletion, 'block_opencast');
             }
@@ -159,6 +162,7 @@ if (has_capability('moodle/site:config', context_system::instance())) {
     $entry->publishtoengage = get_config('block_opencast', 'publishtoengage');
     $entry->reuseexistingupload = get_config('block_opencast', 'reuseexistingupload');
     $entry->allowunassign = get_config('block_opencast', 'allowunassign');
+    $entry->deleteworkflow = get_config('block_opencast', 'deleteworkflow');
     $entry->adhocfiledeletion = get_config('block_opencast', 'adhocfiledeletion');
 
     // Section overview settings.

--- a/classes/admin_form.php
+++ b/classes/admin_form.php
@@ -163,7 +163,8 @@ class admin_form extends moodleform {
         $name = 'workflow_roles';
         $title = get_string('workflowrolesname', 'block_opencast');
         $description = get_string('workflowrolesdesc', 'block_opencast');
-        $mform->addElement('select', $name, $title, $apibridge->get_existing_workflows('archive'));
+        $mform->addElement('select', $name, $title, array_merge($noworkflow,
+            $apibridge->get_existing_workflows('archive')));
         $mform->setType($name, PARAM_TEXT);
         $mform->addElement('static', 'description' . $name, '', $description);
 

--- a/classes/admin_form.php
+++ b/classes/admin_form.php
@@ -85,6 +85,16 @@ class admin_form extends moodleform {
         $mform->setDefault($name, 0);
         $mform->addElement('static', 'description' . $name, '', $description);
 
+        // Delete workflow.
+        $noworkflow = [null => get_string("adminchoice_noworkflow", "block_opencast")];
+        $name = 'deleteworkflow';
+        $title = get_string('deleteworkflow', 'block_opencast');
+        $description = get_string('deleteworkflowdesc', 'block_opencast');
+        $mform->addElement('select', $name, $title, array_merge($noworkflow,
+            $apibridge->get_existing_workflows('delete')));
+        $mform->setType($name, PARAM_TEXT);
+        $mform->addElement('static', 'description' . $name, '', $description);
+
         // Configurate, whether a videofile should be deleted from moodle's filesystem
         // right after the file was transferred (uploaded) to opencast server.
         // The plugin deletes all files in users draft area, which are related to

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -1036,13 +1036,17 @@ class apibridge {
      */
     public function can_delete_event_assignment($video, $courseid) {
 
-        if (!isset($video->processing_state) || ($video->processing_state != 'SUCCEEDED')) {
-            return false;
+        if (isset($video->processing_state) &&
+            ($video->processing_state === 'SUCCEEDED' || $video->processing_state === 'PLANNED')) {
+
+            $context = \context_course::instance($courseid);
+
+            return has_capability('block/opencast:deleteevent', $context);
         }
 
-        $context = \context_course::instance($courseid);
+        return false;
+    }
 
-        return has_capability('block/opencast:deleteevent', $context);
     }
 
     /**

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -230,6 +230,9 @@ class apibridge {
             return $result;
         }
 
+        // Enrich processing state.
+        $this->check_for_planned_videos($video);
+
         $result->video = $video;
 
         return $result;

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -934,12 +934,24 @@ class apibridge {
     private function update_metadata($event) {
         $workflow = get_config('block_opencast', 'workflow_roles');
 
+        return $this->start_workflow($event, $workflow);
+    }
+
+    /**
+     * Starts a workflow in the opencast system.
+     * @param string $eventid event id in the opencast system.
+     * @param string $workflow identifier of the workflow to be started.
+     * @return bool true, if successfully started.
+     * @throws \dml_exception
+     * @throws \moodle_exception
+     */
+    private function start_workflow($eventid, $workflow) {
         if (!$workflow) {
             return false;
         }
 
         // Get mediapackage xml.
-        $resource = '/assets/episode/' . $event;
+        $resource = '/assets/episode/' . $eventid;
         $api = new api();
         $mediapackage = $api->oc_get($resource);
 

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -1047,15 +1047,37 @@ class apibridge {
         return false;
     }
 
+    /**
+     * Triggers the deletion of an event. Dependent on the settings a deletion workflow is started in advance.
+     *
+     * @param string $eventidentifier
+     * @return boolean return true when video deletion is triggerd correctly.
+     */
+    public function trigger_delete_event($eventidentifier) {
+        global $DB;
+        $workflow = get_config("block_opencast", "deleteworkflow");
+        if ($workflow) {
+            $this->start_workflow($eventidentifier, $workflow);
+
+            $record = [
+                "opencasteventid" => $eventidentifier,
+                "failed" => false,
+                "timecreated" => time(),
+                "timemodified" => time()
+            ];
+            $DB->insert_record("block_opencast_deletejob", $record);
+        } else {
+            $this->delete_event($eventidentifier);
+        }
+        return true;
     }
 
     /**
      * Delete an event. Verify the video and check capability before.
      *
      * @param string $eventidentifier
-     * @return boolean return true when video is deleted after double check.
+     * @return boolean return true when video is deleted.
      */
-
     public function delete_event($eventidentifier) {
 
         $resource = '/api/events/' . $eventidentifier;

--- a/classes/task/process_delete_cron.php
+++ b/classes/task/process_delete_cron.php
@@ -1,0 +1,76 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package   block_opencast
+ * @copyright 2018 Tobias Reischmann, WWU
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace block_opencast\task;
+use block_opencast\local\apibridge;
+
+defined('MOODLE_INTERNAL') || die();
+
+class process_delete_cron extends \core\task\scheduled_task {
+
+    public function get_name() {
+        return get_string('processdelete', 'block_opencast');
+    }
+
+    public function execute() {
+        global $DB;
+
+        // Get all delete jobs.
+        $sql = "SELECT * FROM {block_opencast_deletejob}";
+
+        $jobs = $DB->get_records_sql($sql);
+
+        if (!$jobs) {
+            mtrace('...no jobs to proceed');
+        }
+
+        foreach ($jobs as $job) {
+            mtrace('proceed: ' . $job->id);
+            try {
+                $apibridge = apibridge::get_instance();
+                $event = $apibridge->get_opencast_video($job->opencasteventid);
+                // If job failed previously and event does no longer exist, remove the delete job.
+                if ($event->error == 404 & $job->failed) {
+                    $DB->delete_records("block_opencast_deletejob", array('id' => $job->id));
+                    mtrace('failed job ' . $job->id . ' removed');
+                }
+                // If deletion workflow finished, remove the video.
+                if ($event->error == 0 &&
+                    ($event->video->processing_state === "SUCCEEDED" ||
+                        $event->video->processing_state === "PLANNED" )) {
+                    $apibridge->delete_event($job->opencasteventid);
+                    $DB->delete_records("block_opencast_deletejob", array('id' => $job->id));
+                    mtrace('event ' . $job->opencasteventid . ' removed');
+                }
+                // Mark delete job as failed.
+                if ($event->error !== 0) {
+                    $job->failed = true;
+                    $job->timemodified = time();
+                    $DB->update_record("block_opencast_deletejob", $job);
+                    mtrace('deletion of event ' . $job->opencasteventid . ' failed');
+                }
+            } catch (\moodle_exception $e) {
+                mtrace('Job failed due to: ' . $e);
+                $this->upload_failed($job, $e->getMessage());
+            }
+        }
+    }
+}

--- a/db/install.xml
+++ b/db/install.xml
@@ -23,6 +23,18 @@
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
     </TABLE>
+    <TABLE NAME="block_opencast_deletejob" COMMENT="Videos to be deleted by cron job.">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="opencasteventid" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="failed" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
     <TABLE NAME="block_opencast_roles" COMMENT="Additional ACL roles for uploading a video">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -33,4 +33,13 @@ $tasks = array(
         'dayofweek' => '*',
         'month' => '*'
     ),
+    array(
+        'classname' => 'block_opencast\task\process_delete_cron',
+        'blocking' => 0,
+        'minute' => '*',
+        'hour' => '*',
+        'day' => '*',
+        'dayofweek' => '*',
+        'month' => '*'
+    ),
 );

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -144,5 +144,29 @@ function xmldb_block_opencast_upgrade($oldversion) {
         upgrade_block_savepoint(true, 2018080300, 'opencast');
     }
 
+    if ($oldversion < 2018082800) {
+
+        // Define table block_opencast_deletejob to be created.
+        $table = new xmldb_table('block_opencast_deletejob');
+
+        // Adding fields to table block_opencast_deletejob.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('opencasteventid', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('failed', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+
+        // Adding keys to table block_opencast_deletejob.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+
+        // Conditionally launch create table for block_opencast_deletejob.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Opencast savepoint reached.
+        upgrade_block_savepoint(true, 2018082800, 'opencast');
+    }
+
     return true;
 }

--- a/deleteevent.php
+++ b/deleteevent.php
@@ -54,8 +54,8 @@ $video = $opencast->get_opencast_video($identifier);
 if (($action == 'delete') && confirm_sesskey()) {
     // Do action.
     if ($video->video) {
-        if ($opencast->delete_event($video->video->identifier)) {
-            $message = get_string('eventdeleted', 'block_opencast', $video->video);
+        if ($opencast->trigger_delete_event($video->video->identifier)) {
+            $message = get_string('eventdeletionstarted', 'block_opencast', $video->video);
             redirect($redirecturl, $message);
         } else {
             $message = get_string('eventdeletedfailed', 'block_opencast', $video->video);

--- a/index.php
+++ b/index.php
@@ -87,7 +87,7 @@ $table->define_baseurl($baseurl);
 
 $table->no_sorting('action');
 $table->no_sorting('published');
-$table->sortable(true);
+$table->sortable(true, "start_date");
 
 $table->pageable(true);
 $table->is_downloadable(false);

--- a/lang/en/block_opencast.php
+++ b/lang/en/block_opencast.php
@@ -42,6 +42,7 @@ $string['adhocfiledeletiondesc'] = 'If activated the plugin tries to delete the 
     Please note that the file will still remain in the file system, if it is used within other places in moodle.';
 $string['addvideo'] = 'Add video';
 $string['addrole'] = 'Add new role';
+$string['adminchoice_noworkflow'] = "-- No workflow-- ";
 $string['changevisibility_visible'] = 'Revoke access by students.';
 $string['changevisibility_mixed'] = 'The video is hidden for a few nonpermanent ACL roles but not for all. Clicking the icon, will hide the video for all nonpermanent ACL roles.';
 $string['changevisibility_hidden'] = 'Show the video. It is currently hidden for nonpermanent ACL roles.';
@@ -61,6 +62,8 @@ $string['deleteeventdesc'] = 'You are about to delete this video permanently and
 $string['deletegroupacldesc'] = 'You are about to delete the access to this video from this course.
     If the access is deleted, the video is not displayed in filepicker and in the list of available videos. This does not affect videos, which are already embedded.
     The video will not be deleted in Opencast.';
+$string['deleteworkflow'] = 'Workflow to start before event is be deleted';
+$string['deleteworkflowdesc'] = 'Before deleting a video, a workflow can be defined, which is called to retract the event from all publication channels.';
 $string['dodeleteaclgroup'] = 'Delete access to videos from this course';
 $string['editseriesforcourse'] = 'Edit series mapping';
 $string['form_seriesid'] = 'Series ID';

--- a/lang/en/block_opencast.php
+++ b/lang/en/block_opencast.php
@@ -69,6 +69,7 @@ $string['editseriesforcourse'] = 'Edit series mapping';
 $string['form_seriesid'] = 'Series ID';
 $string['form_seriestitle'] = 'Series title';
 $string['dodeleteevent'] = 'Delete video permanently';
+$string['deleting'] = 'Going to be deleted';
 $string['edituploadjobs'] = 'Add video / Edit upload tasks';
 $string['eventdeleted'] = 'The video has been deleted.';
 $string['eventdeletedfailed'] = 'Failed to delete the event';

--- a/lang/en/block_opencast.php
+++ b/lang/en/block_opencast.php
@@ -126,6 +126,7 @@ $string['overview'] = 'Overview';
 $string['planned'] = 'Planned';
 $string['pluginname'] = 'Opencast Videos';
 $string['processupload'] = 'Process upload';
+$string['processdelete'] = 'Process delete jobs for Opencast';
 $string['publishtoengage'] = 'Publish to Engage';
 $string['publishtoengagedesc'] = 'Select this option to publish the video after upload to engage player. Setup workflow must support this.';
 $string['reuseexistingupload'] = 'Reuse existing uploads';

--- a/lang/en/block_opencast.php
+++ b/lang/en/block_opencast.php
@@ -72,6 +72,7 @@ $string['dodeleteevent'] = 'Delete video permanently';
 $string['edituploadjobs'] = 'Add video / Edit upload tasks';
 $string['eventdeleted'] = 'The video has been deleted.';
 $string['eventdeletedfailed'] = 'Failed to delete the event';
+$string['eventdeletionstarted'] = 'The video will be deleted shortly.';
 $string['eventuploadsucceeded'] = 'Upload succeeded';
 $string['eventuploadfailed'] = 'Upload failed';
 $string['errorgetblockvideos'] = 'List cannot be loaded (Error: {$a})';

--- a/renderer.php
+++ b/renderer.php
@@ -64,6 +64,8 @@ class block_opencast_renderer extends plugin_renderer_base {
                 return $this->output->pix_icon('failed', get_string('ocstatefailed', 'block_opencast'), 'block_opencast');
             case 'PLANNED' :
                 return $this->output->pix_icon('c/event', get_string('planned', 'block_opencast'));
+            case 'DELETING' :
+                return $this->output->pix_icon('t/delete', get_string('deleting', 'block_opencast'));
             default :
                 return $this->output->pix_icon('processing', get_string('ocstateprocessing', 'block_opencast'), 'block_opencast');
         }

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2018082700;
+$plugin->version = 2018082800;
 $plugin->requires = 2017051500;
 $plugin->maturity  = MATURITY_BETA;
 $plugin->release   = 'v3.4-r1'; // Developed under Moodle 3.4. First release.


### PR DESCRIPTION
In this PR we introduce a new setting, which enables to specify an delete workflow, which will be called prior to the deletion of an event. This is necessary in standard Opencast installations, since events have to be retracted from publication channels before actually deleting them.