### PR TITLE
Change the visibility based on moodle groups

### DIFF
--- a/classes/groupaccess.php
+++ b/classes/groupaccess.php
@@ -14,18 +14,38 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace block_opencast;
+defined('MOODLE_INTERNAL') || die;
+
 /**
- * Version details
+ * Persistable of seriesmapping
  *
- * @package    block_opencast
- * @copyright  2017 Andreas Wagner, SYNERGY LEARNING
+ * @package    tool_opencast
+ * @copyright  2018 Tobias Reischmann WWU
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2018082802;
-$plugin->requires = 2017051500;
-$plugin->maturity  = MATURITY_BETA;
-$plugin->release   = 'v3.4-r1'; // Developed under Moodle 3.4. First release.
-$plugin->component = 'block_opencast';
-$plugin->dependencies = array('tool_opencast' => 2018070400);
+class groupaccess extends \core\persistent {
+
+    /** Table name for the persistent. */
+    const TABLE = 'block_opencast_groupaccess';
+
+    /**
+     * Return the definition of the properties of this model.
+     *
+     * @return array
+     */
+    protected static function define_properties() {
+        return array(
+            'id' => array(
+                'type' => PARAM_INT,
+            ),
+            'opencasteventid' => array(
+                'type' => PARAM_ALPHANUMEXT,
+            ),
+            'groups' => array(
+                'type' => PARAM_SEQUENCE,
+            ),
+        );
+    }
+}

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -146,9 +146,7 @@ class apibridge {
      *
      * @return array
      */
-    public function get_course_videos($courseid, $table, $perpage, $download) {
-        $sortcolums = $table->get_sort_columns();
-        $sort = api::get_sort_param($sortcolums);
+    public function get_course_videos($courseid, $sortcolumns = null) {
 
         $result = new \stdClass();
         $result->videos = array();
@@ -161,7 +159,11 @@ class apibridge {
         }
         $seriesfilter = "series:" . $series->identifier;
 
-        $query = 'sign=1&withacl=1&withmetadata=1&withpublications=1&filter=' . urlencode($seriesfilter) . $sort;
+        $query = 'sign=1&withacl=1&withmetadata=1withpublications=1&filter=' . urlencode($seriesfilter);
+        if ($sortcolumns) {
+            $sort = api::get_sort_param($sortcolumns);
+            $query .= $sort;
+        }
 
         $resource = '/api/events?' . $query;
 

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -321,6 +321,35 @@ class apibridge {
     }
 
     /**
+     * Persist the new groups for the eventid;
+     * @param string $eventid id of the event
+     * @param int[] $groups ids of all groups for which access should be provided.
+     * If $groups is empty the access is not restricted.
+     * @return bool
+     */
+    private function store_group_access($eventid, $groups) {
+        try {
+            $groupaccess = groupaccess::get_record(array('opencasteventid' => $eventid));
+            if ($groupaccess) {
+                if (empty($groups)) {
+                    $groupaccess->delete();
+                } else {
+                    $groupaccess->set('groups', implode(',', $groups));
+                    $groupaccess->update();
+                }
+            } else {
+                $groupaccess = new groupaccess();
+                $groupaccess->set('opencasteventid', $eventid);
+                $groupaccess->set('groups', implode(',', $groups));
+                $groupaccess->create();
+            }
+        } catch (\moodle_exception $e){
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * Retrieves the id of the series, which is stored in the admin tool.
      *
      * @param int $courseid id of the course.

--- a/classes/local/visibility_form.php
+++ b/classes/local/visibility_form.php
@@ -1,0 +1,102 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Create series form.
+ *
+ * @package    block_opencast
+ * @copyright  2018 Tamara Gunkel
+ * @author     Tamara Gunkel
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace block_opencast\local;
+
+use block_opencast\groupaccess;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+
+require_once($CFG->dirroot . '/lib/formslib.php');
+
+class visibility_form extends \moodleform {
+
+    public function definition() {
+        $mform = $this->_form;
+
+        $apibridge = \block_opencast\local\apibridge::get_instance();
+
+        $courseid = $this->_customdata['courseid'];
+        $eventid = $this->_customdata['identifier'];
+        $visibility = $this->_customdata['visibility'];
+
+        $mform->addElement('hidden', 'courseid', $courseid);
+        $mform->setType('courseid', PARAM_INT);
+
+        $mform->addElement('hidden', 'identifier', $eventid);
+        $mform->setType('identifier', PARAM_INT);
+
+        // Check if there are roles, which allow group visibility.
+        $roles = $apibridge->getroles(array("permanent" => 0));
+        $groupvisibilityallowed = false;
+        foreach ($roles as $role) {
+            if (strpos($role->rolename, '[COURSEGROUPID]') >= 0) {
+                $groupvisibilityallowed = true;
+                break;
+            }
+        }
+
+        $groups = groups_get_all_groups($courseid);
+
+        $radioarray=array();
+        $radioarray[] = $mform->addElement('radio', 'visibility',
+            get_string('visibility', 'block_opencast'), get_string('visibility_hide', 'block_opencast'), 0);
+        $radioarray[] = $mform->addElement('radio', 'visibility', '', get_string('visibility_show', 'block_opencast'), 1);
+        if ($groupvisibilityallowed) {
+            $attributes = array();
+            if (empty($groups)) {
+                $attributes = array('disabled' => true);
+            }
+            $radioarray[] = $mform->addElement('radio', 'visibility', '', get_string('visibility_group', 'block_opencast'), 2,
+                $attributes);
+        }
+        $mform->setDefault('visibility', $visibility);
+        $mform->setType('visibility', PARAM_INT);
+
+        // Load existing groups.
+        if ($groupvisibilityallowed) {
+
+            $options = [];
+
+            foreach ($groups as $group) {
+                $options[$group->id] = $group->name;
+            }
+
+            $select = $mform->addElement('select', 'groups', get_string('groups'), $options);
+            $select->setMultiple(true);
+
+            $selectedgroups = groupaccess::get_record(array('opencasteventid' => $eventid));
+            if ($selectedgroups && $groups = $selectedgroups->get('groups')) {
+                $groupsarray = explode(',', $groups);
+                $select->setSelected($groupsarray);
+            }
+            $mform->hideIf('groups', 'visibility', 'neq', 2);
+        }
+
+        $this->add_action_buttons(true, get_string('savechanges'));
+    }
+}

--- a/db/install.xml
+++ b/db/install.xml
@@ -35,6 +35,18 @@
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
     </TABLE>
+    <TABLE NAME="block_opencast_groupaccess" COMMENT="Groups which have access to videos">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="opencasteventid" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="groups" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Comma-separated list of group ids"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
     <TABLE NAME="block_opencast_roles" COMMENT="Additional ACL roles for uploading a video">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -168,5 +168,29 @@ function xmldb_block_opencast_upgrade($oldversion) {
         upgrade_block_savepoint(true, 2018082800, 'opencast');
     }
 
+    if ($oldversion < 2018082802) {
+
+        // Define table block_opencast_groupaccess to be created.
+        $table = new xmldb_table('block_opencast_groupaccess');
+
+        // Adding fields to table block_opencast_groupaccess.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('opencasteventid', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('groups', XMLDB_TYPE_TEXT, null, null, XMLDB_NOTNULL, null, null);
+        $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+
+        // Adding keys to table block_opencast_groupaccess.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+
+        // Conditionally launch create table for block_opencast_groupaccess.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Opencast savepoint reached.
+        upgrade_block_savepoint(true, 2018082802, 'opencast');
+    }
+
     return true;
 }

--- a/index.php
+++ b/index.php
@@ -104,7 +104,8 @@ $table->setup();
 $perpage = optional_param('perpage', 20, PARAM_INT);
 
 $opencast = \block_opencast\local\apibridge::get_instance();
-$videodata = $opencast->get_course_videos($courseid, $table, $perpage, $download);
+$sortcolumns = $table->get_sort_columns();
+$videodata = $opencast->get_course_videos($courseid, $sortcolumns);
 
 $renderer = $PAGE->get_renderer('block_opencast');
 

--- a/lang/en/block_opencast.php
+++ b/lang/en/block_opencast.php
@@ -23,16 +23,20 @@
  */
 
 $string['aclgroupdeleted'] = 'Access deleted for video: {$a->title}';
-$string['aclrolesadded'] = 'Not permanent acl roles added for video: {$a->title}
+$string['aclrolesadded'] = 'The change of visibility has been triggered to allow all students of the course to access the video: {$a->title}
 
-Please refresh the site to see the current visibility status.';
-$string['aclrolesaddederror'] = 'Error during adding not permanent acl roles for video: {$a->title}
-Some roles might have not been added.';
-$string['aclrolesdeleted'] = 'Not permanent acl roles were deleted for video: {$a->title}
+Please refresh the site after some time to see the current visibility status.';
+$string['aclroleschangeerror'] = 'Error during the change of visibility of the video: {$a->title}
 
-Please refresh the site to see the current visibility status.';
-$string['aclrolesdeletederror'] = 'Error during deleting not permanent acl roles for video: {$a->title}
-Some roles might have not been deleted.';
+Some changes might have not been saved.
+If this occurs repeatedly, please contact your support team.';
+$string['aclrolesdeleted'] = 'The change of visibility has been triggered to prevent all students of the course from accessing the video: {$a->title}
+
+Please refresh the site after some time to see the current visibility status.';
+$string['aclrolesaddedgroup'] = 'The change of visibility has been triggered to allow students of selected groups to access the video: {$a->title}
+
+Please refresh the site after some time to see the current visibility status.';
+$string['aclnothingtobesaved'] = 'No changes to the visibility have been made.';
 $string['accesspolicies'] = 'Access Policies';
 $string['aclrolesname'] = 'Roles';
 $string['aclrolesnamedesc'] = 'You can use the placeholder [COURSEID] in the role name which is automatically replaced.';
@@ -43,9 +47,12 @@ $string['adhocfiledeletiondesc'] = 'If activated the plugin tries to delete the 
 $string['addvideo'] = 'Add video';
 $string['addrole'] = 'Add new role';
 $string['adminchoice_noworkflow'] = "-- No workflow-- ";
-$string['changevisibility_visible'] = 'Revoke access by students.';
-$string['changevisibility_mixed'] = 'The video is hidden for a few nonpermanent ACL roles but not for all. Clicking the icon, will hide the video for all nonpermanent ACL roles.';
-$string['changevisibility_hidden'] = 'Show the video. It is currently hidden for nonpermanent ACL roles.';
+$string['changevisibility_visible'] = 'The video is visible to all students of the course. Click to alter visibility.';
+$string['changevisibility_mixed'] = 'The visibility of the video is in an invalid status. Click to choose the correct visibility.';
+$string['changevisibility_hidden'] = 'The video is visible to no student. Click to alter visibility.';
+$string['changevisibility_group'] = 'The video is visible to all student belonging to selected groups. Click to alter visibility.';
+$string['changevisibility_header'] = 'Change visibility for {$a->title}';
+$string['changevisibility'] = 'Alter visibility';
 $string['allowunassign'] = 'Allow unassign from course';
 $string['allowunassigndesc'] = 'Delete the assignment of a course series to control visibility in filepicker and course lists. This feature is only available,
     when it is possible to have events without series in opencast. Please ask the admistrator of the opencast system before activating this.';
@@ -160,6 +167,10 @@ $string['uploadworkflowdesc'] = 'Setup the unique shortname of the workflow, tha
 $string['videosavailable'] = 'Videos available in this course';
 $string['videonotfound'] = 'Video not found';
 $string['videostoupload'] = 'Videos to upload to opencast';
+$string['visibility'] = 'Visibility of the video';
+$string['visibility_hide'] = 'Prevent any student from accessing the video';
+$string['visibility_show'] = 'Allow all students of the course to access the video';
+$string['visibility_group'] = 'Allow all students belonging to selected groups to access the video';
 $string['workflownotdefined'] = 'The workflow for updating metadata is not defined.';
 $string['worklowisrunning'] = 'A workflow is running. You cannot change the visibility at the moment.';
 $string['workflowrolesname'] = 'Workflow for changing the ACL rules';

--- a/renderer.php
+++ b/renderer.php
@@ -32,10 +32,10 @@ defined('MOODLE_INTERNAL') || die;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class block_opencast_renderer extends plugin_renderer_base {
-    const VISIBLE = 2;
-    const MIXED_VISIBLITY = 1;
+    const VISIBLE = 1;
+    const MIXED_VISIBLITY = 3;
     const HIDDEN = 0;
-
+    const GROUP = 2;
 
     /**
      * Render the opencast timestamp in moodle standard format.
@@ -205,17 +205,25 @@ class block_opencast_renderer extends plugin_renderer_base {
     public function render_change_visibility_icon($courseid, $videoidentifier, $visible) {
         global $USER;
         $url = new \moodle_url('/blocks/opencast/changevisibility.php',
-            array('identifier' => $videoidentifier, 'courseid' => $courseid, 'visible' => $visible, 'sesskey' => $USER->sesskey));
+            array('identifier' => $videoidentifier, 'courseid' => $courseid, 'visibility' => $visible, 'sesskey' => $USER->sesskey));
 
-        if ($visible === self::VISIBLE) {
-            $text = get_string('changevisibility_visible', 'block_opencast');
-            $icon = $this->output->pix_icon('t/hide', $text);
-        } else if ($visible === self::MIXED_VISIBLITY) {
-            $text = get_string('changevisibility_mixed', 'block_opencast');
-            $icon = $this->output->pix_icon('i/warning', $text);
-        } else {
-            $text = get_string('changevisibility_hidden', 'block_opencast');
-            $icon = $this->output->pix_icon('t/show', $text);
+        switch ($visible) {
+            case self::VISIBLE:
+                $text = get_string('changevisibility_visible', 'block_opencast');
+                $icon = $this->output->pix_icon('t/hide', $text);
+                break;
+            case self::MIXED_VISIBLITY:
+                $text = get_string('changevisibility_mixed', 'block_opencast');
+                $icon = $this->output->pix_icon('i/warning', $text);
+                break;
+            case self::GROUP:
+                $text = get_string('changevisibility_group', 'block_opencast');
+                $icon = $this->output->pix_icon('t/groups', $text);
+                break;
+            case self::HIDDEN:
+                $text = get_string('changevisibility_hidden', 'block_opencast');
+                $icon = $this->output->pix_icon('t/show', $text);
+                break;
         }
 
         return \html_writer::link($url, $icon);


### PR DESCRIPTION
This pull request introduces a new placeholder [COURSEGROUPID].
Additionally it is possible to set the visibility of events by a set of moodle groups.
If groups 12 and 42 are selected this results in the ACL rules for the pattern LEARNER_[COURSEGROUPID]:
LEARNER_G42
LEARNER_G12
If no group is selected for a video in course 2, the ACL rule
LEARNER_2
is created, which is in sync with the LTI standard.