### PR TITLE
Call WS endpoints based on API level

### DIFF
--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -203,8 +203,8 @@ class apibridge {
      */
     private function check_for_planned_videos(&$video) {
 
-        $compatibilitymode = get_config('tool_opencast', 'compatibilitymode');
-        if ($compatibilitymode == 5) {
+        $api = new api();
+        if (!$api->supports_api_level('v1.1.0')) {
             $resourceopencast5 = '/recordings/' . $video->identifier . '/technical.json';
             $api = new api();
             $plannedvideo = json_decode($api->oc_get($resourceopencast5));
@@ -1161,8 +1161,8 @@ class apibridge {
             return false;
         }
 
-        $compatibilitymode = get_config('tool_opencast', 'compatibilitymode');
-        if ($compatibilitymode == 5) {
+        $api = new api();
+        if (!$api->supports_api_level('v1.1.0')) {
             // Get mediapackage xml.
             $resourceopencast5 = '/assets/episode/' . $eventid;
             $api = new api();
@@ -1224,8 +1224,8 @@ class apibridge {
     public function get_existing_workflows($tag = '') {
         if (!array_key_exists($tag, $this->workflows)) {
 
-            $compatibilitymode = get_config('tool_opencast', 'compatibilitymode');
-            if ($compatibilitymode == 5) {
+            $api = new api();
+            if (!$api->supports_api_level('v1.1.0')) {
                 $resourceopencast5 = '/workflow/definitions.json';
                 $api = new api();
                 $result = $api->oc_get($resourceopencast5);

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -205,9 +205,9 @@ class apibridge {
 
         $compatibilitymode = get_config('tool_opencast', 'compatibilitymode');
         if ($compatibilitymode == 5) {
-            $resource = '/recordings/' . $video->identifier . '/technical.json';
+            $resourceopencast5 = '/recordings/' . $video->identifier . '/technical.json';
             $api = new api();
-            $plannedvideo = json_decode($api->oc_get($resource));
+            $plannedvideo = json_decode($api->oc_get($resourceopencast5));
 
             if ($api->get_http_code() === 200 && $plannedvideo->state === "") {
                 $video->processing_state = "PLANNED";
@@ -1164,18 +1164,18 @@ class apibridge {
         $compatibilitymode = get_config('tool_opencast', 'compatibilitymode');
         if ($compatibilitymode == 5) {
             // Get mediapackage xml.
-            $resource = '/assets/episode/' . $eventid;
+            $resourceopencast5 = '/assets/episode/' . $eventid;
             $api = new api();
-            $mediapackage = $api->oc_get($resource);
+            $mediapackage = $api->oc_get($resourceopencast5);
 
             // Start workflow.
-            $resource = '/workflow/start';
+            $resourceopencast5 = '/workflow/start';
             $params = [
                 'definition'   => $workflow,
                 'mediapackage' => rawurlencode($mediapackage)
             ];
             $api = new api();
-            $api->oc_post($resource, $params);
+            $api->oc_post($resourceopencast5, $params);
 
             if ($api->get_http_code() != 200) {
                 return false;
@@ -1226,9 +1226,9 @@ class apibridge {
 
             $compatibilitymode = get_config('tool_opencast', 'compatibilitymode');
             if ($compatibilitymode == 5) {
-                $resource = '/workflow/definitions.json';
+                $resourceopencast5 = '/workflow/definitions.json';
                 $api = new api();
-                $result = $api->oc_get($resource);
+                $result = $api->oc_get($resourceopencast5);
 
                 if ($api->get_http_code() === 200) {
                     $returnedworkflows = json_decode($result);

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -202,12 +202,27 @@ class apibridge {
      * @param $video The video object, which should be checked.
      */
     private function check_for_planned_videos(&$video) {
-        $resource = '/recordings/'. $video->identifier .'/technical.json';
-        $api = new api();
-        $plannedvideo = json_decode($api->oc_get($resource));
 
-        if ($api->get_http_code() === 200 && $plannedvideo->state === "") {
-            $video->processing_state = "PLANNED";
+        $compatibilitymode = get_config('tool_opencast', 'compatibilitymode');
+        if ($compatibilitymode == 5) {
+            $resource = '/recordings/' . $video->identifier . '/technical.json';
+            $api = new api();
+            $plannedvideo = json_decode($api->oc_get($resource));
+
+            if ($api->get_http_code() === 200 && $plannedvideo->state === "") {
+                $video->processing_state = "PLANNED";
+            }
+        } else {
+            $resource = '/api/events/' . $video->identifier . '/scheduling';
+            $api = new api();
+            $plannedvideo = json_decode($api->oc_get($resource));
+
+            if ($api->get_http_code() === 200 && $plannedvideo->end) {
+                $endtime = strtotime($plannedvideo->end);
+                if ($endtime > time()) {
+                    $video->processing_state = "PLANNED";
+                }
+            }
         }
     }
 

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -1255,18 +1255,16 @@ class apibridge {
             } else {
                 $resource = '/api/workflow-definitions';
                 $api = new api();
-                $params = [
-                    'tag'    => $tag,
-                ];
-                $result = $api->oc_get($resource, $params);
+                $resource .= '?filter=tag:'.$tag;
+                $result = $api->oc_get($resource);
                 if ($api->get_http_code() === 200) {
                     $returnedworkflows = json_decode($result);
                     $this->workflows[$tag] = array();
                     foreach ($returnedworkflows as $workflow) {
                         if (object_property_exists($workflow, 'title') && !empty($workflow->title)) {
-                            $this->workflows[$tag][$workflow->id] = $workflow->title;
+                            $this->workflows[$tag][$workflow->identifier] = $workflow->title;
                         } else {
-                            $this->workflows[$tag][$workflow->id] = $workflow->id;
+                            $this->workflows[$tag][$workflow->identifier] = $workflow->identifier;
                         }
                     }
                 } else {

--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -1190,7 +1190,7 @@ class apibridge {
             $api = new api();
             $api->oc_post($resource, $params);
 
-            if ($api->get_http_code() != 200) {
+            if ($api->get_http_code() != 201) {
                 return false;
             }
         }

--- a/version.php
+++ b/version.php
@@ -28,4 +28,4 @@ $plugin->requires = 2017051500;
 $plugin->maturity  = MATURITY_BETA;
 $plugin->release   = 'v3.4-r1'; // Developed under Moodle 3.4. First release.
 $plugin->component = 'block_opencast';
-$plugin->dependencies = array('tool_opencast' => 2018090300);
+$plugin->dependencies = array('tool_opencast' => 2018090301);


### PR DESCRIPTION
I added a check for the current API level of the opencast server. In case of the old API level v1.0.0 we use some WS endpoints, which require ROLE_ADMIN in order to work. At this API level we have no other choice. With API level v1.1.0 we can use the new endpoints of the external API and remove the necessity of giving the external user admin privileges.