### PR TITLE
Fixed block context not being used for system blocks

### DIFF
--- a/classes/local/upload_helper.php
+++ b/classes/local/upload_helper.php
@@ -503,13 +503,21 @@ class upload_helper {
         global $DB;
 
         $sql = "SELECT bi.* FROM {block_instances} bi
-                JOIN {context} ctx on ctx.id = bi.parentcontextid AND ctx.contextlevel = :contextlevel
-                WHERE bi.blockname = :blockname AND ctx.instanceid = :instanceid";
+                JOIN {context} ctx ON ctx.id = bi.parentcontextid
+                WHERE bi.blockname = :blockname
+                AND (
+                    ctx.contextlevel = :contextlevelsystem
+                    OR (
+                        ctx.contextlevel = :contextlevelcourse
+                        AND ctx.instanceid = :courseid
+                    )
+                )";
 
         $params = [
-            'contextlevel' => CONTEXT_COURSE,
+            'contextlevelcourse' => CONTEXT_COURSE,
+            'contextlevelsystem' => CONTEXT_SYSTEM,
             'blockname' => 'opencast',
-            'instanceid' => $courseid
+            'courseid' => $courseid
         ];
 
         if (!$blockinstance = $DB->get_record_sql($sql, $params)) {


### PR DESCRIPTION
You can add a block in the system context as opposed to the course
context. If you do that the upload form uses the course context. That's
arguably not correct as it doesn't respect the capabilities set in the
block context.