### PR TITLE
[WIP] Added new state "in cutting"

### DIFF
--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -189,12 +189,27 @@ class apibridge {
         if ($result->error == 0) {
             foreach ($videos as $video) {
                 $this->check_for_planned_videos($video);
+                $this->check_for_videos_in_cutting($video);
             }
         }
 
         $result->videos = $videos;
 
         return $result;
+    }
+
+    /**
+     * Check if a video is currently in cutting/postproduction.
+     * This is the case if it is currently in state proceeding, but not yet published anywhere but internal.
+     * @param $video The video object, which should be checked.
+     */
+    private function check_for_videos_in_cutting(&$video) {
+
+        if ($video->processing_state == "SUCCEEDED" &&
+                count($video->publication_state) == 1 &&
+                $video->publication_state[0] = 'internal') {
+            $video->processing_state = "CUTTING";
+        }
     }
 
     /**

--- a/lang/en/block_opencast.php
+++ b/lang/en/block_opencast.php
@@ -155,6 +155,7 @@ $string['setting_permanent'] = 'Is permanent';
 $string['show_public_channels'] = 'Show publications channels';
 $string['show_public_channels_desc'] = 'If ticked, the users can see the column with the publication channels in the list of the published videos.';
 $string['submit'] = 'Save changes';
+$string['ocstatecutting'] = 'Cutting';
 $string['ocstatefailed'] = 'Failed';
 $string['ocstateprocessing'] = 'Processing';
 $string['ocstatesucceeded'] = 'Succeeded';

--- a/renderer.php
+++ b/renderer.php
@@ -64,6 +64,8 @@ class block_opencast_renderer extends plugin_renderer_base {
                 return $this->output->pix_icon('c/event', get_string('planned', 'block_opencast'));
             case 'DELETING' :
                 return $this->output->pix_icon('t/delete', get_string('deleting', 'block_opencast'));
+            case 'CUTTING' :
+                return $this->output->pix_icon('processing', get_string('ocstateprocessing', 'block_opencast'), 'block_opencast');
             case 'RUNNING' :
             case 'PAUSED' :
                 return $this->output->pix_icon('processing', get_string('ocstateprocessing', 'block_opencast'), 'block_opencast');


### PR DESCRIPTION
We are currently unsure, how to identify if a event is "in cutting". In our system it is currently a comment at the media package. But it is difficult to retrieve this using the external API. It would be helpful to know, if other institutes would like to have this state to be displayed, as well. And how this state is represented in their system.