### PR TITLE
Make duplicate workflow setting optional

### DIFF
--- a/classes/admin_form.php
+++ b/classes/admin_form.php
@@ -131,7 +131,8 @@ class admin_form extends moodleform {
         $name = 'duplicateworkflow';
         $title = get_string('duplicateworkflow', 'block_opencast');
         $description = get_string('duplicateworkflowdesc', 'block_opencast');
-        $mform->addElement('select', $name, $title, $apibridge->get_existing_workflows('api'));
+        $mform->addElement('select', $name, $title, array_merge($noworkflow,
+            $apibridge->get_existing_workflows('api')));
         $mform->setType($name, PARAM_TEXT);
         $mform->addElement('static', 'description' . $name, '', $description);
 


### PR DESCRIPTION
Currently, the duplicate workflow has no option 'no workflow'. This way, it leads to problems, if no workflow with api label exists or if the admin just does not want to use the backup & restore feature.

This PR adds this option.