### PR TITLE
Update list of default roles which are added to a series

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,14 @@ In the ACL Roles the following placeholders can be used:
  In case that multiple groups are selected in the visibility dialog, one ACL rule for every group is created.
  The basic role including the course id is removed in the case of group visibility.
     
-To give an example for Roles, which also meets the LTI standard, you can use the following setting:
+To give an example for Roles, which also meets the LTI standard and which is used by the plugin by default, you can use the following setting:
 
-| Role                    | Actions    | Permanent |
-| ------------------------|------------|-----------|
-| ROLE_ADMIN              | write,read | Yes       |
-| [COURSEID]_Instructor   | write,read | Yes       |
-| [COURSEGROUPID]_Learner | read       | No        |
+| Role                                            | Actions    | Permanent |
+| ------------------------------------------------|------------|-----------|
+| ROLE_ADMIN                                      | write,read | Yes       |
+| ROLE_GROUP_MH_DEFAULT_ORG_EXTERNAL_APPLICATIONS | write,read | Yes       |
+| [COURSEID]_Instructor                           | write,read | Yes       |
+| [COURSEGROUPID]_Learner                         | read       | No        |
     
 
 Capabilities

--- a/db/install.php
+++ b/db/install.php
@@ -42,8 +42,8 @@ function xmldb_block_opencast_install() {
     $record[0]->permanent = true;
 
     $record[1] = new \stdClass();
-    $record[1]->rolename = 'ROLE_GROUP_MOODLE_COURSE_[COURSEID]';
-    $record[1]->actions = 'read';
+    $record[1]->rolename = 'ROLE_GROUP_MH_DEFAULT_ORG_EXTERNAL_APPLICATIONS';
+    $record[1]->actions = 'write,read';
     $record[1]->permanent = true;
 
     $record[2] = new \stdClass();

--- a/tests/roles_test.php
+++ b/tests/roles_test.php
@@ -46,7 +46,7 @@ class block_opencast_roles_testcase extends advanced_testcase {
 
         $expected = [
             'ROLE_ADMIN' => ['write', 'read'],
-            'ROLE_GROUP_MOODLE_COURSE_[COURSEID]' => ['read'],
+            'ROLE_GROUP_MH_DEFAULT_ORG_EXTERNAL_APPLICATIONS' => ['write', 'read'],
             '[COURSEID]_Instructor' => ['write', 'read'],
             '[COURSEGROUPID]_Learner' => ['read'],
             'testrole1' => ['action1'],


### PR DESCRIPTION
This patch removes ROLE_GROUP_MOODLE_COURSE_[COURSEID] as role which is added to a series by default as it is not relevant for default installations.
On the other hand, it adds ROLE_GROUP_MH_DEFAULT_ORG_EXTERNAL_APPLICATIONS as role which is added to a series by default as this role is needed to let Moodle fetch series information.

This change is only applied to new installations.
Existing installations which are mostly configured by experienced admins in custom ways are not changed.