### PR TITLE
Change block_opencast\task\process_upload_cron schedule - Fixes #84

### DIFF
--- a/db/tasks.php
+++ b/db/tasks.php
@@ -27,8 +27,8 @@ $tasks = array(
     array(
         'classname' => 'block_opencast\task\process_upload_cron',
         'blocking' => 0,
-        'minute' => '0',
-        'hour' => '0',
+        'minute' => '*',
+        'hour' => '*',
         'day' => '*',
         'dayofweek' => '*',
         'month' => '*'


### PR DESCRIPTION
This patch changes the default schedule of the block_opencast\task\process_upload_cron
task to run every minute instead of once per day at midnight.