### PR TITLE
Disables video upload

### DIFF
--- a/index.php
+++ b/index.php
@@ -137,9 +137,8 @@ if (has_capability('block/opencast:addvideo', $coursecontext)) {
     $videojobs = \block_opencast\local\upload_helper::get_upload_jobs($courseid);
     echo $renderer->render_upload_jobs($videojobs);
 
-    $addvideourl = new moodle_url('/blocks/opencast/addvideo.php', array('courseid' => $courseid));
-    $addvideobutton = $OUTPUT->single_button($addvideourl, get_string('addvideo', 'block_opencast'));
-    echo html_writer::div($addvideobutton);
+        $addvideourl = new moodle_url('/blocks/opencast/uploadvideo.php', array('courseid' => $courseid));
+        $addvideobutton = $OUTPUT->single_button($addvideourl, get_string('addvideo', 'block_opencast'));
 
     if (get_config('block_opencast', 'enable_opencast_studio_link')) {
         $recordvideo = new moodle_url('/blocks/opencast/recordvideo.php', array('courseid' => $courseid));

--- a/index.php
+++ b/index.php
@@ -137,8 +137,11 @@ if (has_capability('block/opencast:addvideo', $coursecontext)) {
     $videojobs = \block_opencast\local\upload_helper::get_upload_jobs($courseid);
     echo $renderer->render_upload_jobs($videojobs);
 
+    if (get_config('block_opencast', 'enable_upload_video')) {
         $addvideourl = new moodle_url('/blocks/opencast/uploadvideo.php', array('courseid' => $courseid));
         $addvideobutton = $OUTPUT->single_button($addvideourl, get_string('addvideo', 'block_opencast'));
+        echo html_writer::div($addvideobutton);
+    }
 
     if (get_config('block_opencast', 'enable_opencast_studio_link')) {
         $recordvideo = new moodle_url('/blocks/opencast/recordvideo.php', array('courseid' => $courseid));

--- a/lang/en/block_opencast.php
+++ b/lang/en/block_opencast.php
@@ -315,6 +315,8 @@ $string['presentationfilesize'] = 'Filesize (Presentation)';
 $string['addnewcatalogfield'] = 'A new field has been added to metadata catalog.';
 $string['recordvideo'] = 'Record video';
 $string['heading_lti'] = 'Setting for LTI Configuration';
+$string['enableuploadvideo'] = 'Allow to upload videos into Opencast';
+$string['enableuploadvideo_desc'] = 'This option allows videos to be uploaded into Opencast.';
 $string['enableopencaststudiolink'] = 'Show the link to opencast studio';
 $string['enableopencaststudiolink_desc'] = 'This option renders a button to opencast studio in the block content and the block overview.
 Opencast studio has to run on your opencast admin node and the following lti settings have to be configured as well.';

--- a/renderer.php
+++ b/renderer.php
@@ -89,8 +89,11 @@ class block_opencast_renderer extends plugin_renderer_base {
         $coursecontext = context_course::instance($courseid);
 
         if (has_capability('block/opencast:addvideo', $coursecontext)) {
+            if (get_config('block_opencast', 'enable_upload_video')) {
                 $addvideourl = new moodle_url('/blocks/opencast/uploadvideo.php', array('courseid' => $courseid));
                 $addvideobutton = $this->output->single_button($addvideourl, get_string('addvideo', 'block_opencast'));
+                $html .= html_writer::div($addvideobutton, 'opencast-addvideo-wrap');
+            }
 
             if (get_config('block_opencast', 'enable_opencast_studio_link')) {
                 $recordvideo = new moodle_url('/blocks/opencast/recordvideo.php', array('courseid' => $courseid));

--- a/renderer.php
+++ b/renderer.php
@@ -89,9 +89,8 @@ class block_opencast_renderer extends plugin_renderer_base {
         $coursecontext = context_course::instance($courseid);
 
         if (has_capability('block/opencast:addvideo', $coursecontext)) {
-            $addvideourl = new moodle_url('/blocks/opencast/addvideo.php', array('courseid' => $courseid));
-            $addvideobutton = $this->output->single_button($addvideourl, get_string('addvideo', 'block_opencast'));
-            $html .= html_writer::div($addvideobutton, 'opencast-addvideo-wrap');
+                $addvideourl = new moodle_url('/blocks/opencast/uploadvideo.php', array('courseid' => $courseid));
+                $addvideobutton = $this->output->single_button($addvideourl, get_string('addvideo', 'block_opencast'));
 
             if (get_config('block_opencast', 'enable_opencast_studio_link')) {
                 $recordvideo = new moodle_url('/blocks/opencast/recordvideo.php', array('courseid' => $courseid));

--- a/settings.php
+++ b/settings.php
@@ -46,6 +46,11 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
             ''));
 
     $additionalsettings->add(
+        new admin_setting_configcheckbox('block_opencast/enable_upload_video',
+            get_string('enableuploadvideo', 'block_opencast'),
+            get_string('enableuploadvideo_desc', 'block_opencast'), 1));
+
+    $additionalsettings->add(
         new admin_setting_configcheckbox('block_opencast/enable_opencast_studio_link',
             get_string('enableopencaststudiolink', 'block_opencast'),
             get_string('enableopencaststudiolink_desc', 'block_opencast'), 0));

--- a/uploadvideo.php
+++ b/uploadvideo.php
@@ -35,6 +35,10 @@ $PAGE->set_url($baseurl);
 
 $redirecturl = new moodle_url('/blocks/opencast/index.php', array('courseid' => $courseid));
 
+if (!get_config('block_opencast', 'enable_upload_video')) {
+    redirect($redirecturl);
+}
+
 require_login($courseid, false);
 
 // Use block context for this page to ignore course file upload limit.

--- a/uploadvideo.php
+++ b/uploadvideo.php
@@ -16,7 +16,7 @@
 
 /**
  *
- * * @package    block_opencast
+ * @package    block_opencast
  * @copyright  2017 Andreas Wagner, SYNERGY LEARNING
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -30,7 +30,7 @@ require_once($CFG->dirroot . '/repository/lib.php');
 
 $courseid = required_param('courseid', PARAM_INT);
 
-$baseurl = new moodle_url('/blocks/opencast/addvideo.php', array('courseid' => $courseid));
+$baseurl = new moodle_url('/blocks/opencast/uploadvideo.php', array('courseid' => $courseid));
 $PAGE->set_url($baseurl);
 
 $redirecturl = new moodle_url('/blocks/opencast/index.php', array('courseid' => $courseid));
@@ -51,7 +51,7 @@ $PAGE->navbar->add(get_string('addvideo', 'block_opencast'), $baseurl);
 $coursecontext = context_course::instance($courseid);
 require_capability('block/opencast:addvideo', $coursecontext);
 
-$metadata_catalog = upload_helper::get_opencast_metadata_catalog();  
+$metadata_catalog = upload_helper::get_opencast_metadata_catalog();
 
 $addvideoform = new \block_opencast\local\addvideo_form(null, array('courseid' => $courseid, 'metadata_catalog' => $metadata_catalog));
 


### PR DESCRIPTION
This commit introduces a new configuration setting to disable video upload.
It removes both links to uploadvideo.php (former addvideo.php) and prevents the usage of this function if disabled.