### PR TITLE
Relabel the feature to delete the video before the transfer to Opencast

### DIFF
--- a/deletedraft.php
+++ b/deletedraft.php
@@ -45,7 +45,7 @@ $PAGE->set_heading(get_string('pluginname', 'block_opencast'));
 
 $redirecturl = new moodle_url('/blocks/opencast/index.php', array('courseid' => $courseid));
 $PAGE->navbar->add(get_string('pluginname', 'block_opencast'), $redirecturl);
-$PAGE->navbar->add(get_string('dodeleteevent', 'block_opencast'), $baseurl);
+$PAGE->navbar->add(get_string('deletedraft', 'block_opencast'), $baseurl);
 
 // Capability check.
 // the one who is allowed to add the video is also allowed to delete the video before it is uploaded
@@ -61,13 +61,13 @@ foreach ($uploadjobs as $uploadjob) {
     }
 }
 if(!$jobtodelete) {
-    $message = get_string('videonotfound', 'block_opencast');
-    redirect($redirecturl, $message);
+    $message = get_string('videodraftnotfound', 'block_opencast');
+    redirect($redirecturl, $message, null, \core\output\notification::NOTIFY_WARNING);
 }
 if($jobtodelete->status != upload_helper::STATUS_READY_TO_UPLOAD) {
     $message = get_string('videodraftnotdeletable', 'block_opencast',
                           upload_helper::get_status_string($jobtodelete->status));
-    redirect($redirecturl, $message);
+    redirect($redirecturl, $message, null, \core\output\notification::NOTIFY_WARNING);
 }
 
 
@@ -80,10 +80,12 @@ if (($action == 'delete') && confirm_sesskey()) {
     redirect($redirecturl, $message);
 }
 
+$html = $OUTPUT->notification(get_string('deletedraftdesc', 'block_opencast'), 'error');
 
 $renderer = $PAGE->get_renderer('block_opencast');
-$html = $renderer->render_upload_jobs([$jobtodelete], false);
-$label = get_string('dodeleteevent', 'block_opencast');
+$html .= $renderer->render_upload_jobs([$jobtodelete], false);
+
+$label = get_string('dodeletedraft', 'block_opencast');
 $params = array(
         'identifier' => $identifier,
         'courseid' => $courseid,
@@ -93,6 +95,6 @@ $urldelete = new \moodle_url('/blocks/opencast/deletedraft.php', $params);
 $html .= $OUTPUT->confirm($label, $urldelete, $redirecturl);
 
 echo $OUTPUT->header();
-echo $OUTPUT->heading(get_string('dodeleteevent', 'block_opencast'));
+echo $OUTPUT->heading(get_string('deletedraft', 'block_opencast'));
 echo $html;
 echo $OUTPUT->footer();

--- a/lang/en/block_opencast.php
+++ b/lang/en/block_opencast.php
@@ -135,12 +135,11 @@ $string['cronsettings'] = 'Settings for upload jobs';
 $string['deleteaclgroup'] = 'Delete video from this list.';
 $string['delete_confirm_role'] = 'Are you sure you want to delete this role?';
 $string['delete_confirm_catalog'] = 'Are you sure you want to delete this catalog entry?';
-$string['deleteevent'] = 'Delete a event in opencast';
-$string['deleteeventdesc'] = 'You are about to delete this video permanently and irreversibly from opencast.
-    All embedded links to it will become invalid. Please do not continue unless you are absolutely sure.';
-$string['deletegroupacldesc'] = 'You are about to delete the access to this video from this course.
-    If the access is deleted, the video is not displayed in filepicker and in the list of available videos. This does not affect videos, which are already embedded.
-    The video will not be deleted in Opencast.';
+$string['deleteevent'] = 'Delete an event in Opencast';
+$string['deleteeventdesc'] = 'You are about to delete this video permanently and irreversibly from Opencast.<br />All embedded links to it will become invalid. Please do not continue unless you are absolutely sure.';
+$string['deletedraft'] = 'Delete a video before transfer to Opencast';
+$string['deletedraftdesc'] = 'You are about to delete this video before the transfer to Opencast.<br />It will be removed from the transfer queue and will not be processed. Please do not continue unless you are absolutely sure.';
+$string['deletegroupacldesc'] = 'You are about to delete the access to this video from this course.<br />If the access is deleted, the video is not displayed in filepicker and in the list of available videos. This does not affect videos, which are already embedded.<br />The video will not be deleted in Opencast.';
 $string['deleteworkflow'] = 'Workflow to start before event is be deleted';
 $string['deleteworkflowdesc'] = 'Before deleting a video, a workflow can be defined, which is called to retract the event from all publication channels.';
 $string['dodeleteaclgroup'] = 'Delete access to videos from this course';
@@ -154,6 +153,7 @@ $string['failedtransferattempts'] = 'Failed transfer attempts: {$a}';
 $string['form_seriesid'] = 'Series ID';
 $string['form_seriestitle'] = 'Series title';
 $string['dodeleteevent'] = 'Delete video permanently';
+$string['dodeletedraft'] = 'Delete video before transfer to Opencast';
 $string['deleting'] = 'Going to be deleted';
 $string['error_eventid_taskdata_missing'] = 'The task data contains no event id.
     Opencast duplicate event task ({$a->taskid}) for course {$a->coursefullname} (ID: {$a->courseid}).';
@@ -288,6 +288,7 @@ $string['uploadworkflowdesc'] = 'Setup the unique shortname of the workflow, tha
     If left blank the standard workflow (ng-schedule-and-upload) will be used. Ask for additional workflows that may have been created by the opencast administrator.';
 $string['videosavailable'] = 'Videos available in this course';
 $string['videonotfound'] = 'Video not found';
+$string['videodraftnotfound'] = 'The video to be deleted before the transfer to Opencast was not found.';
 $string['videostoupload'] = 'Videos to upload to opencast';
 $string['visibility'] = 'Visibility of the video';
 $string['visibility_hide'] = 'Prevent any student from accessing the video';
@@ -383,7 +384,7 @@ $string['lticonsumersecret'] = 'Consumer secret';
 $string['lticonsumersecret_desc'] = 'LTI Consumer secret for the opencast studio integration.';
 $string['opencaststudiointegration'] = 'Opencast studio integration';
 
-$string['videodraftnotdeletable'] = 'The video cannot be deleted as the status is already "{$a}"';
+$string['videodraftnotdeletable'] = 'The video cannot be deleted anymore before the transfer to Opencast as the processing status is already "{$a}"';
 $string['videodraftdeletionsucceeded'] = 'The video is deleted successfully';
 
 $string['cachedef_videodata'] = 'Caches the result of the opencast api for the opencast-block.';


### PR DESCRIPTION
This commit improves the strings of the feature which allows the teacher to delete a video before the transfer to Opencast.
This feature was labeled "Delete video permanently", but the substring "permanently" is not really accurate as the video is still in the draft status and not yet available for anyone at all.

In addition to that, this patch separates all strings of this feature from the strings of the permanent deletion feature.

In addition to that, this patch also adds some explanation to the deletedraft.php page to better explain to the teacher what will happen as soon as he confirms the deletion.